### PR TITLE
UI bugfixes on map: Swap HP and AP icons

### DIFF
--- a/build/MapState.pde
+++ b/build/MapState.pde
@@ -288,8 +288,8 @@ class MapState extends GameState {
     }
 
     private void drawStatusInfo() {
-        image(APIcon,1485,0);
-        image(HPIcon,1485,65);
+        image(HPIcon,1485,0);
+        image(APIcon,1485,65);
 
         // Draw Health Point
             fill(255, 0, 0);


### PR DESCRIPTION
Swap HP and AP icons to fix the display bug in case misleading users
