### PR TITLE
Improve the experience of gameplay flow

### DIFF
--- a/build/CombatState.pde
+++ b/build/CombatState.pde
@@ -34,13 +34,20 @@ class CombatState extends GameState {
 
         switch (combatOutcome) {
             case OUTCOME_WIN:
-                toChangeTo = new EndState(engineRef, passedPlayer, true);
                 BGMplayer.musicStop();
+                toChangeTo = new EndState(engineRef, passedPlayer, true);
                 changeState(engineRef, toChangeTo);
                 break;
             case OUTCOME_LOSS:
-                toChangeTo = new EndState(engineRef, passedPlayer, false);
                 BGMplayer.musicStop();
+                int bossHP = 50;
+                for (Enemy enemy : encounterEnemies) {
+                    if(enemy instanceof Boss){
+                        bossHP = enemy.getCurrHp();
+                        break; 
+                    }
+                }
+                toChangeTo = new EndState(engineRef, passedPlayer, false,bossHP);
                 changeState(engineRef, toChangeTo);
                 break;
             default:

--- a/build/EndState.pde
+++ b/build/EndState.pde
@@ -9,9 +9,10 @@ class EndState extends GameState {
   private Player passedPlayer;
   int winBonus = 2; //suppose the player will get 5 points after winning
   int sacrificeFine = 1; //suppose the player will lose 5 points after lose
-  int sacrificeHp = 20; //suppose the player will get 10 hp after losing 5 points
+  int sacrificeHp = 40; //suppose the player will get 10 hp after losing 5 points
   int actionPoints;
   int totalPoints;
+  int bossCurrHP;
   int buttonWidth;
   int buttonHeight;
   String warningMessage = "Blocked! "; // Warning message content
@@ -28,14 +29,7 @@ class EndState extends GameState {
     actionPoints = player.getActionPts();
     if (checkWin) {
       player.incrementActionPts(winBonus);
-      String gameWinBgmPath = sketchPath("../assets/music/StagedWin.wav");
-      BGMplayer.musicLoad(gameWinBgmPath);
-      BGMplayer.musicPlay();
     } else {
-      String gameOverBgmPath = sketchPath("../assets/music/GameOver.wav");
-      BGMplayer.musicLoad(gameOverBgmPath);
-      BGMplayer.musicPlay();
-      //player.decrementActionPts(sacrificeFine);
     }
     totalPoints = player.getActionPts();
     MapState mapStateFake = new MapState(engineRef, passedPlayer);
@@ -43,6 +37,51 @@ class EndState extends GameState {
     mapStateFake.saveMapStateToFile("../assets/map/mapTemp.json");
     checkFinalWin = mapStateFake.checkFinalWin();
     setupState();
+    if (checkWin && (!checkFinalWin)) {
+      String gameWinBgmPath = sketchPath("../assets/music/StagedWin.wav");
+      BGMplayer.musicLoad(gameWinBgmPath);
+      BGMplayer.musicPlay();
+    } else if(checkFinalWin && checkWin){
+      String finalWinBGMPath = sketchPath("../assets/music/FinalWin.wav");
+      BGMplayer.musicLoad(finalWinBGMPath);
+      BGMplayer.musicPlay();
+    }else {
+      String gameOverBgmPath = sketchPath("../assets/music/GameOver.wav");
+      BGMplayer.musicLoad(gameOverBgmPath);
+      BGMplayer.musicPlay();
+    }
+  }
+
+  EndState(GameEngine engine, Player player, boolean check, int bossHP) {
+    System.out.println("I am called.I am end");
+    passedPlayer = player;
+    engineRef = engine;
+    checkWin = check;
+    bossCurrHP = bossHP;
+    actionPoints = player.getActionPts();
+    if (checkWin) {
+      player.incrementActionPts(winBonus);
+    } else {
+    }
+    totalPoints = player.getActionPts();
+    MapState mapStateFake = new MapState(engineRef, passedPlayer);
+    mapStateFake.updateNodeStatesOutside();
+    mapStateFake.saveMapStateToFile("../assets/map/mapTemp.json");
+    checkFinalWin = mapStateFake.checkFinalWin();
+    setupState();
+    if (checkWin && (!checkFinalWin)) {
+      String gameWinBgmPath = sketchPath("../assets/music/StagedWin.wav");
+      BGMplayer.musicLoad(gameWinBgmPath);
+      BGMplayer.musicPlay();
+    } else if(checkFinalWin && checkWin){
+      String finalWinBGMPath = sketchPath("../assets/music/FinalWin.wav");
+      BGMplayer.musicLoad(finalWinBGMPath);
+      BGMplayer.musicPlay();
+    }else {
+      String gameOverBgmPath = sketchPath("../assets/music/GameOver.wav");
+      BGMplayer.musicLoad(gameOverBgmPath);
+      BGMplayer.musicPlay();
+    }
   }
 
   public void setupState() {
@@ -69,7 +108,7 @@ class EndState extends GameState {
         mapStateFake.updateNodeStatesOutside();
         mapStateFake.saveMapStateToFile("../assets/map/mapTemp.json");
         checkFinalWin = mapStateFake.checkFinalWin();
-        if(checkFinalWin){
+        if(checkFinalWin&&checkWin){
           System.out.println("WinWinWin!!!");
           String filePath = "../assets/map/mapTemp.json";
           try {
@@ -82,6 +121,11 @@ class EndState extends GameState {
           }
           MenuState menuState = new MenuState(engineRef, passedPlayer);
           engineRef.changeState(menuState);
+        }else if(checkFinalWin && (!checkWin) && (totalPoints >= 0)){
+          MapState bossState = new MapState(engineRef, passedPlayer,bossCurrHP);
+          bossState.fightBossAgain();
+          bossState.saveMapStateToFile("../assets/map/mapTemp.json");
+          engineRef.changeState(bossState);
         }else{
           MapState mapStateTrue = new MapState(engineRef, passedPlayer);
           engineRef.changeState(mapStateTrue);
@@ -112,7 +156,7 @@ class EndState extends GameState {
       cleanScreen();
       textSize(128);
       textAlign(CENTER, CENTER);
-      if (checkFinalWin) {
+      if (checkFinalWin && checkWin) {
         background(finalImage);
         continueButton.drawButton();
         fill(0, 255, 0);

--- a/build/Entity.pde
+++ b/build/Entity.pde
@@ -45,6 +45,10 @@ abstract class Entity {
         }
     }
 
+    public void setHP(int amt){
+        currHp = amt;
+    }
+
     public void gainHealth(int initialAmt) {
         int finalAmt = applyModifiers(BuffHealMod.class, initialAmt);
         incrementHp(finalAmt);

--- a/build/MapState.pde
+++ b/build/MapState.pde
@@ -22,6 +22,8 @@ class MapState extends GameState {
     boolean bossOrNot = false; 
     String warningMessage = "Blocked! "; // Warning message content
     boolean showTutorial = false; // Show Tutorial or not
+    boolean fightBossAgain = false;
+    int bossCurrHP = 50;
 
 
     MapState(GameEngine engine, Player thePlayer) {
@@ -41,6 +43,17 @@ class MapState extends GameState {
         BGMplayer.musicLoad(bgmPath);
         BGMplayer.musicPlay();
         setupState(hardmode);
+        drawState();
+    }
+
+    MapState(GameEngine engine, Player thePlayer, int bossHP) {
+        engineRef = engine;
+        passedPlayer = thePlayer;
+        bossCurrHP = bossHP;
+        String bgmPath = sketchPath("../assets/music/RegularFlowBGM.wav");
+        BGMplayer.musicLoad(bgmPath);
+        BGMplayer.musicPlay();
+        setupState();
         drawState();
     }
 
@@ -344,6 +357,9 @@ class MapState extends GameState {
         if(bossOrNot){
             ArrayList<Enemy> enemiesBoss = new ArrayList<Enemy>();
             Boss boss = new Boss(passedPlayer);
+            if(fightBossAgain){
+                boss.setHP(bossCurrHP);
+            }
             enemiesBoss.add(boss);
             CombatState bossState = new CombatState(engineRef, passedPlayer, enemiesBoss);
             BGMplayer.musicStop();
@@ -682,6 +698,17 @@ class MapState extends GameState {
                 }else if (nodeLevel == 1 && (minLevelWithCurrent - nodeLevel) <= currAP) {
                     node.clickable = true; // Destination special result
                 }
+            }
+        }
+        BGMplayer.musicStop();
+    }
+
+    public void fightBossAgain(){
+        fightBossAgain = true;
+        for (Node node : nodes) {
+            int nodeLevel = getLevelAsInt(node.level);
+            if (nodeLevel == 1 ) {
+                node.clickable = true; 
             }
         }
         BGMplayer.musicStop();

--- a/build/MenuState.pde
+++ b/build/MenuState.pde
@@ -20,7 +20,7 @@ class MenuState extends GameState {
 
     public void setupState() {
         
-        passedPlayer = new Player("Initial", 40, 5, 5, 2, 4, 20); //Initialize the player
+        passedPlayer = new Player("Initial", 40, 5, 5, 5, 4, 20); //Initialize the player
         
 
         bg = loadImage("../assets/main/menu_bg.jpeg");


### PR DESCRIPTION
Hi Team
@A-PS1999  @JThakral20  @erer1022  @Doctor-TOTORO 
After much personal trial and debugging, I've made a few tweaks to the mechanics
* In view of the increased difficulty right, user is particularly easy to die in easymode, so the initial AP adjustment to 5, AP sacrificed supplementary HP adjustment to 40
* In order to make the AP system more meaningful, I allow players to sacrifice AP to challenge bosses repeatedly in boss levels if they have extra AP.
* When repeatedly adjusting the boss, the HP of the boss will be inherited from the remaining HP of the boss when the player fails.

The following changes have been made to fix bugs already encountered prior to the mechanic change
* Adjusted the final win display logic in EndState to prevent the final victory screen from being displayed when the player is DEFINITELY dead.
* Adjusted the music pause code to ensure seamless integration without music overlap.
